### PR TITLE
Hotfix to allow relative paths for input

### DIFF
--- a/extract_text/xml_to_text.py
+++ b/extract_text/xml_to_text.py
@@ -113,7 +113,7 @@ def issue_to_text(publication,
         issue_out_path = os.path.join(issue_out_dir, issue_out_stub)
         try:
             xslt(document_tree,
-                 input_path=etree.XSLT.strparam(issue_dir),
+                 input_path=etree.XSLT.strparam(os.path.abspath(issue_dir)),
                  input_sub_path=etree.XSLT.strparam(input_sub_path),
                  input_filename=etree.XSLT.strparam(input_filename),
                  output_document_stub=etree.XSLT.strparam(


### PR DESCRIPTION
Should allow relative and absolute paths to be used for `xml_in_dir` parameter

request:
* check outputs are the same for absolute and relative path runs, `diff` is your friend
* check that relative and absolute paths work for `txt_out_dir` parameter