### PR TITLE
xlst select source note

### DIFF
--- a/extract_text/xslts/extract_text_mets18.xslt
+++ b/extract_text/xslts/extract_text_mets18.xslt
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:exsl="http://exslt.org/common"
-                xmlns:math="http://exslt.org/math"
-                extension-element-prefixes="exsl"
-                xmlns:dc="http://purl.org/dc/elements/1.1/"
-                xmlns:mets="http://www.loc.gov/METS/"
-                xmlns:mods="http://www.loc.gov/mods/v3"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:exsl="http://exslt.org/common"
+  xmlns:math="http://exslt.org/math"
+  extension-element-prefixes="exsl"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:mets="http://www.loc.gov/METS/"
+  xmlns:mods="http://www.loc.gov/mods/v3"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
   <xsl:include href="extract_text_common.xslt"/>
-  
+
   <xsl:template match="/">
     <xsl:apply-templates select="/mets:mets" />
   </xsl:template>
-  
+
   <xsl:key name="page_doc_area" match="/doc/alto/Layout//ComposedBlock|doc/alto/Layout//TextBlock" use="@ID" />
   <xsl:key name="smLocatorLink_href" match="/mets:mets/mets:structLink/mets:smLinkGrp/mets:smLocatorLink" use="@xlink:href" />
   <xsl:key name="smLocatorLink_label" match="/mets:mets/mets:structLink/mets:smLinkGrp/mets:smLocatorLink" use="@xlink:label" />
   <xsl:key name="structMap" match="/mets:mets/mets:structMap[@TYPE='PHYSICAL']//mets:div" use="@ID" />
-  
+
   <xsl:template match="/mets:mets">
     <xsl:variable name="page_docs_rt">
       <xsl:for-each select="mets:fileSec//mets:fileGrp[@USE='Fulltext']/mets:file">
@@ -31,16 +31,16 @@
         </doc>
       </xsl:for-each>
     </xsl:variable>
-    
+
     <xsl:variable name="page_docs" select="exsl:node-set($page_docs_rt)" />
-    
+
     <xsl:for-each select="mets:structMap[@TYPE='LOGICAL']/mets:div">
       <xsl:variable name="issue_DMDID" select="@DMDID" />
       <xsl:for-each select="mets:div">
         <xsl:variable name="item_ID" select="@ID" />
         <xsl:variable name="item_ID_hash">#<xsl:value-of select="$item_ID" /></xsl:variable>
         <xsl:variable name="item_DMDID" select="@DMDID" />
-        
+
         <xsl:variable name="item_page_areas_rt">
           <xsl:for-each select="key('smLocatorLink_href', $item_ID_hash)/../mets:smArcLink/@xlink:to">
             <xsl:variable name="pagearea" select="key('smLocatorLink_label', .)/@xlink:href" />
@@ -56,9 +56,9 @@
             </xsl:for-each>
           </xsl:for-each>
         </xsl:variable>
-        
+
         <xsl:variable name="item_page_areas" select="exsl:node-set($item_page_areas_rt)" />
-        
+
         <exsl:document method="text" href="{$output_path}_{$item_ID}.txt">
           <xsl:choose>
             <xsl:when test="$item_page_areas//String|$item_page_areas//HYP">
@@ -74,29 +74,29 @@
             </xsl:otherwise>
           </xsl:choose>
         </exsl:document>
-        
+
         <xsl:variable name="item_word_confidences_rt">
           <xsl:for-each select="$item_page_areas//String/@WC">
             <w><xsl:value-of select="." /></w>
           </xsl:for-each>
         </xsl:variable>
-        
+
         <xsl:variable name="item_word_confidences" select="exsl:node-set($item_word_confidences_rt)" />
-        
+
         <xsl:variable name="word_count" select="count($item_word_confidences/w)" />
         <xsl:variable name="ocr_quality_sum" select="sum($item_word_confidences/w)" />
         <xsl:variable name="ocr_quality_mean" select="$ocr_quality_sum div $word_count" />
-        
+
         <xsl:variable name="standard_deviation_square_and_mean_rt">
           <xsl:for-each select="$item_word_confidences/w">
             <w><xsl:value-of select="math:power(. - $ocr_quality_mean, 2)" /></w>
           </xsl:for-each>
         </xsl:variable>
-        
+
         <xsl:variable name="standard_deviation_square_and_mean" select="exsl:node-set($standard_deviation_square_and_mean_rt)" />
-        
+
         <xsl:variable name="standard_deviation" select="math:sqrt(sum($standard_deviation_square_and_mean/w) div $word_count)" />
-        
+
         <exsl:document method="xml" href="{$output_path}_{$item_ID}_metadata.xml" indent="yes">
           <lwm>
             <process>
@@ -123,7 +123,7 @@
                     <!-- If missing then use date as issue ID -->
                     <xsl:attribute name="id"><xsl:value-of select="/mets:mets/mets:dmdSec[@ID=$issue_DMDID]//mods:dateIssued" /></xsl:attribute>
                   </xsl:otherwise>
-                </xsl:choose>
+     	        </xsl:choose>
                 <date><xsl:value-of select="/mets:mets/mets:dmdSec[@ID=$issue_DMDID]//mods:dateIssued" /></date>
                 <item>
                   <xsl:attribute name="id"><xsl:value-of select="$item_ID" /></xsl:attribute>
@@ -147,24 +147,24 @@
             </publication>
           </lwm>
         </exsl:document>
-        
+
       </xsl:for-each>
     </xsl:for-each>
   </xsl:template>
-  
+
   <xsl:template match="TextLine">
     <xsl:apply-templates select="String|HYP|SP" />
     <xsl:text>&#xA;</xsl:text>
   </xsl:template>
-  
+
   <xsl:template match="String|HYP">
     <xsl:value-of select="@CONTENT" />
   </xsl:template>
-  
+
   <xsl:template match="SP">
     <xsl:if test="position()!=last()">
       <xsl:text> </xsl:text>
     </xsl:if>
   </xsl:template>
-  
+
 </xsl:stylesheet>


### PR DESCRIPTION
Ads a 'source' field which gets value from source note. 

I hadn't noticed that vscode went wild with the formatting so the diff is bigger than it should have been - the pertinent line change is 114. Let me know if you want me to update pull request with just that line changed. 