### PR TITLE
Added 'digitised' to the heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `alto2txt`: Extract plain text from newspapers
+# `alto2txt`: Extract plain text from digitised newspapers
 
 ![GitHub](https://img.shields.io/github/license/Living-with-Machines/alto2txt) ![PyPI](https://img.shields.io/pypi/v/alto2txt) [![DOI](https://zenodo.org/badge/259340615.svg)](https://zenodo.org/badge/latestdoi/259340615)
 


### PR DESCRIPTION
METS and ALTO are artefacts of the digitisation process that link metadata and transcribed text to images of the physical page; born-digital newspapers don't use the same formats. So it's a little clearer and it might also aid discoverability.